### PR TITLE
:arrow_up: upgrade webpack-dev-server to 3.1.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "tether": "^1.3.8",
     "url-loader": "^0.5.7",
     "webpack": "^3.5.5",
-    "webpack-dev-server": "^2.7.1"
+    "webpack-dev-server": "^3.1.11"
   },
   "devDependencies": {
     "extract-text-webpack-plugin": "^3.0.0",


### PR DESCRIPTION
Go to the patched version of webpack (https://nvd.nist.gov/vuln/detail/CVE-2018-14732).