### PR TITLE
Fix/relative urls

### DIFF
--- a/src/App/View.elm
+++ b/src/App/View.elm
@@ -181,7 +181,7 @@ showcase _ num page =
         [ div [ class "column is-12 showcase" ]
             [ article [ class "columns featured" ]
                 ([ div [ class "column is-7 showcase-img" ]
-                    [ img [ src <| interpolate "/{0}.png" [ pageHash page ], width 450 ]
+                    [ img [ src <| interpolate "./{0}.png" [ pageHash page ], width 450 ]
                         []
                     ]
                  , div [ class "column is-5 featured-content va" ]


### PR DESCRIPTION
I don’t really like it, but I’ve switched to using relative URLs for images since GitHub Pages are deployed on a subpath.