### PR TITLE
Fix/version and urls

### DIFF
--- a/src/App/View.elm
+++ b/src/App/View.elm
@@ -57,7 +57,7 @@ view model =
 {-| the html elements for the footer
 -}
 footerPart : Model -> Html Msg
-footerPart _ =
+footerPart { flags } =
     footer
         [ class "footer has-background-black-bis" ]
         [ div
@@ -98,7 +98,7 @@ footerPart _ =
                     ]
                 , p []
                     [ strong []
-                        [ text "playground-elm" ]
+                        [ text ("playground-elm v" ++ flags.version) ]
                     , text " | "
                     , a [ href "https://github.com/ccamel" ]
                         [ text "© 2017-2024 Christophe Camel" ]

--- a/src/App/View.elm
+++ b/src/App/View.elm
@@ -175,12 +175,12 @@ pagePart page model =
 
 
 showcase : Model -> Int -> Page -> Html Msg
-showcase _ num page =
+showcase { flags } num page =
     div [ class "columns featured-showcase is-multiline" ]
         [ div [ class "column is-12 showcase" ]
             [ article [ class "columns featured" ]
                 ([ div [ class "column is-7 showcase-img" ]
-                    [ img [ src <| interpolate "./{0}.png" [ pageHash page ], width 450 ]
+                    [ img [ src <| interpolate "{0}{1}.png" [ flags.basePath, pageHash page ], width 450 ]
                         []
                     ]
                  , div [ class "column is-5 featured-content va" ]


### PR DESCRIPTION
Changes:

- Display the application version in the footer (previously missing).
- Revert to using absolute URLs for images, using the `basePath` provided in the [flags](https://guide.elm-lang.org/interop/flags).