### PR TITLE
Ci/capture website

### DIFF
--- a/.github/workflows/capture-website.yml
+++ b/.github/workflows/capture-website.yml
@@ -1,0 +1,56 @@
+name: Capture website
+
+on:
+  workflow_dispatch:
+
+  schedule:
+    - cron: "0 0 1 * *"
+
+concurrency:
+  group: capture-website-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  capture-website:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Setup node environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18.17
+          cache: npm
+
+      - name: Screenshot Website
+        env:
+          WEBSITE_URL: https://ccamel.github.io/playground-elm/
+        run: |
+          npx capture-website-cli@4.0.0 \
+            --type=webp \
+            --quality=0.7 \
+            --launch-options='{"headless": "new"}' \
+            --dark-mode \
+            --output=screenshot.webp \
+            --overwrite \
+            $WEBSITE_URL
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_user_name: ${{ secrets.USER_NAME }}
+          commit_user_email: ${{ secrets.USER_EMAIL }}
+          commit_author: ${{ secrets.USER_NAME }} <${{ secrets.USER_EMAIL }}>
+          commit_message: ":memo: Update website screenshot"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,6 @@ jobs:
       - name: Deploy project to github pages
         run: ./scripts/deploy-to-gh-pages.sh
         env:
-          USER_EMAIL: ${{ secrets.USER_EMAIL }}
-          USER_NAME: ${{ secrets.USER_NAME }}
+          USER_EMAIL: ${{ secrets.USER_EMAIL }}
+          USER_NAME: ${{ secrets.USER_NAME }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -19,11 +19,7 @@
 The purpose of this playground is to explore, study and assess the [elm][] language — a delightful language for reliable
 webapps.
 
-<p align="center">
-   <a href="https://ccamel.github.io/playground-elm/">
-    <img alt="demo-link" src="https://img.shields.io/badge/demo-https%3A%2F%2Fccamel.github.io%2Fplayground--elm%2F-blue?style=for-the-badge&logo=firefox">
-   </a>
-</p>
+[![https://ccamel.github.io/playground-elm/](./screenshot.webp)](https://ccamel.github.io/playground-elm/)
 
 The showcases are intended to be:
 


### PR DESCRIPTION
Uses [capture-website-cli](https://github.com/sindresorhus/capture-website-cli) in the CI to update the screenshot of the [playground website](https://ccamel.github.io/playground-elm/) from the command-line.