### PR TITLE
:arrow_up: adopt node LTS v20.18.1 (iron)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup node environment (for building)
         uses: actions/setup-node@v4
         with:
-          node-version: 18.17
+          node-version: 20.18
           cache: "pnpm"
 
       - name: Fetch dependencies

--- a/.github/workflows/capture-website.yml
+++ b/.github/workflows/capture-website.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup node environment
         uses: actions/setup-node@v4
         with:
-          node-version: 18.17
+          node-version: 20.18
           cache: "pnpm"
 
       - name: Screenshot Website

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup node environment (for building)
         uses: actions/setup-node@v4
         with:
-          node-version: 18.17
+          node-version: 20.18
           cache: "pnpm"
 
       - name: Fetch dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup node environment (for building)
         uses: actions/setup-node@v4
         with:
-          node-version: 18.17
+          node-version: 20.18
           cache: "pnpm"
 
       - name: Fetch dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup node environment (for building)
         uses: actions/setup-node@v4
         with:
-          node-version: 18.17
+          node-version: 20.18
           cache: "pnpm"
 
       - name: Fetch dependencies

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ I finally managed to migrate to this new version but instabilities can be notice
 
 Be sure to have the following properly installed:
 
-- [Node.js](https://nodejs.org/ru/) `v18.17` ([hydrogen](https://nodejs.org/en/blog/release/v18.17.1/))
+- [Node.js](https://nodejs.org/ru/) `v20.18` ([lts/iron](https://nodejs.org/en/blog/release/v20.18.1))
 - [pnpm](https://pnpm.io/) `v8.3`
 
 ### Build

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "email": "camel.christophe@gmail.com"
   },
   "engines": {
-    "node": "^18.17.1",
+    "node": "^20.18.1",
     "pnpm": "^9.1.2"
   },
   "targets": {


### PR DESCRIPTION
Self explanatory.

Required by [release-it](https://github.com/release-it/release-it) [v18.0.0](https://github.com/release-it/release-it/releases/tag/18.0.0) which has dropped support for Node.js v18.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Node.js version from v18.17 to v20.18 across project workflows and configuration files
	- Updated project prerequisite Node.js version in README
	- Updated project engine version in package.json

<!-- end of auto-generated comment: release notes by coderabbit.ai -->